### PR TITLE
config: Jenkins jobs now rely on the shared script

### DIFF
--- a/jobs/clear-containers-agent-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-16-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/agent.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,24 +90,15 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
+export COVERALLS_REPO_TOKEN
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/mattn/goveralls
-go get github.com/clearcontainers/agent || true
-cd $GOPATH/src/github.com/clearcontainers/agent
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;$GOPATH/bin/goveralls -repotoken=$COVERALLS_REPO_TOKEN -coverprofile=profile.cov&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/agent&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-agent-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-16-04-master/config.xml
@@ -46,24 +46,13 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export COVERALLS_REPO_TOKEN
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/mattn/goveralls
-go get github.com/clearcontainers/agent || true
-cd $GOPATH/src/github.com/clearcontainers/agent
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;$GOPATH/bin/goveralls -repotoken=$COVERALLS_REPO_TOKEN -coverprofile=profile.cov&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/agent&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-agent-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-17-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/agent.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,22 +90,14 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/agent || true
-cd $GOPATH/src/github.com/clearcontainers/agent
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/agent&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-agent-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-17-04-master/config.xml
@@ -46,22 +46,11 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/agent || true
-cd $GOPATH/src/github.com/clearcontainers/agent
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/agent&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-agent-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-agent-fedora-26-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/agent.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,23 +90,14 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/agent || true
-cd $GOPATH/src/github.com/clearcontainers/agent
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/agent&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-agent-fedora-26-master/config.xml
+++ b/jobs/clear-containers-agent-fedora-26-master/config.xml
@@ -46,23 +46,11 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/agent || true
-cd $GOPATH/src/github.com/clearcontainers/agent
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/agent&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-proxy-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-16-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/proxy.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,24 +90,15 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
+export COVERALLS_REPO_TOKEN
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/mattn/goveralls
-go get github.com/clearcontainers/proxy || true
-cd $GOPATH/src/github.com/clearcontainers/proxy
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;$GOPATH/bin/goveralls -repotoken=$COVERALLS_REPO_TOKEN -coverprofile=profile.cov&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/proxy&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-proxy-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-16-04-master/config.xml
@@ -46,24 +46,13 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export COVERALLS_REPO_TOKEN
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/mattn/goveralls
-go get github.com/clearcontainers/proxy || true
-cd $GOPATH/src/github.com/clearcontainers/proxy
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;$GOPATH/bin/goveralls -repotoken=$COVERALLS_REPO_TOKEN -coverprofile=profile.cov&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/proxy&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-proxy-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-17-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/proxy.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,22 +90,14 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/proxy || true
-cd $GOPATH/src/github.com/clearcontainers/proxy
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/proxy&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-proxy-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-17-04-master/config.xml
@@ -46,22 +46,11 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/proxy || true
-cd $GOPATH/src/github.com/clearcontainers/proxy
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/proxy&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-proxy-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-proxy-fedora-26-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/proxy.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,23 +90,14 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/proxy || true
-cd $GOPATH/src/github.com/clearcontainers/proxy
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/proxy&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-proxy-fedora-26-master/config.xml
+++ b/jobs/clear-containers-proxy-fedora-26-master/config.xml
@@ -46,23 +46,11 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/proxy || true
-cd $GOPATH/src/github.com/clearcontainers/proxy
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/proxy&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-runtime-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-16-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/runtime.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,24 +90,15 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
+export COVERALLS_REPO_TOKEN
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/mattn/goveralls
-go get github.com/clearcontainers/runtime || true
-cd $GOPATH/src/github.com/clearcontainers/runtime
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-.ci/setup.sh
-.ci/run.sh
-sudo -E PATH=$PATH bash -c &quot;$GOPATH/bin/goveralls -repotoken=$COVERALLS_REPO_TOKEN -coverprofile=profile.cov&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/runtime&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-runtime-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-16-04-master/config.xml
@@ -46,24 +46,13 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export COVERALLS_REPO_TOKEN
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/mattn/goveralls
-go get github.com/clearcontainers/runtime || true
-cd $GOPATH/src/github.com/clearcontainers/runtime
-git fetch origin &amp;&amp; git checkout origin/master
-.ci/setup.sh
-.ci/run.sh
-sudo -E PATH=$PATH bash -c &quot;$GOPATH/bin/goveralls -repotoken=$COVERALLS_REPO_TOKEN -coverprofile=profile.cov&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/runtime&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-runtime-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-17-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/runtime.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,22 +90,14 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/runtime || true
-cd $GOPATH/src/github.com/clearcontainers/runtime
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-.ci/setup.sh
-.ci/run.sh</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/runtime&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-runtime-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-17-04-master/config.xml
@@ -46,22 +46,11 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/runtime || true
-cd $GOPATH/src/github.com/clearcontainers/runtime
-git fetch origin &amp;&amp; git checkout origin/master
-.ci/setup.sh
-.ci/run.sh</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/runtime&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-runtime-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-runtime-fedora-26-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/runtime.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,23 +90,14 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/runtime || true
-cd $GOPATH/src/github.com/clearcontainers/runtime
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-.ci/setup.sh
-.ci/run.sh</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/runtime&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-runtime-fedora-26-master/config.xml
+++ b/jobs/clear-containers-runtime-fedora-26-master/config.xml
@@ -46,23 +46,11 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/runtime || true
-cd $GOPATH/src/github.com/clearcontainers/runtime
-git fetch origin &amp;&amp; git checkout origin/master
-.ci/setup.sh
-.ci/run.sh</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/runtime&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-shim-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-16-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/shim.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,22 +90,14 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/shim || true
-cd $GOPATH/src/github.com/clearcontainers/shim
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/shim&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-shim-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-16-04-master/config.xml
@@ -46,22 +46,11 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/shim || true
-cd $GOPATH/src/github.com/clearcontainers/shim
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/shim&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-shim-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-17-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/shim.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,22 +90,14 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/shim || true
-cd $GOPATH/src/github.com/clearcontainers/shim
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/shim&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-shim-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-17-04-master/config.xml
@@ -46,22 +46,11 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/shim || true
-cd $GOPATH/src/github.com/clearcontainers/shim
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/shim&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-shim-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-shim-fedora-26-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/shim.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,23 +90,14 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-export CI=true
-go get github.com/clearcontainers/shim || true
-cd $GOPATH/src/github.com/clearcontainers/shim
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/shim&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-shim-fedora-26-master/config.xml
+++ b/jobs/clear-containers-shim-fedora-26-master/config.xml
@@ -46,23 +46,11 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+cd $HOME
+git clone https://github.com/clearcontainers/tests.git
+cd tests
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/shim || true
-cd $GOPATH/src/github.com/clearcontainers/shim
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/run.sh&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/shim&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-tests-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-16-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/tests.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,23 +90,10 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/tests || true
-cd $GOPATH/src/github.com/clearcontainers/tests
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup_tests.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;make check&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/tests&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-tests-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-16-04-master/config.xml
@@ -46,23 +46,7 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
-
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/tests || true
-cd $GOPATH/src/github.com/clearcontainers/tests
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup_tests.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;make check&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/tests&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-tests-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-17-04-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/tests.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,23 +90,10 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/tests || true
-cd $GOPATH/src/github.com/clearcontainers/tests
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup_tests.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;make check&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/tests&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-tests-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-17-04-master/config.xml
@@ -46,23 +46,7 @@
 
 set -e
 
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
-
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/tests || true
-cd $GOPATH/src/github.com/clearcontainers/tests
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup_tests.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;make check&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/tests&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-tests-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-tests-fedora-26-PR/config.xml
@@ -17,12 +17,14 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
+        <name>origin</name>
+        <refspec>+refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*</refspec>
         <url>https://github.com/clearcontainers/tests.git</url>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>
     <branches>
       <hudson.plugins.git.BranchSpec>
-        <name>*/master</name>
+        <name>${sha1}</name>
       </hudson.plugins.git.BranchSpec>
     </branches>
     <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
@@ -88,24 +90,10 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
+export ghprbPullId
+export ghprbTargetBranch
 
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/tests || true
-cd $GOPATH/src/github.com/clearcontainers/tests
-git fetch origin pull/${ghprbPullId}/head &amp;&amp; git checkout FETCH_HEAD &amp;&amp; git rebase origin/${ghprbTargetBranch}
-sudo -E PATH=$PATH bash -c &quot;.ci/setup_tests.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;make check&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/tests&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/clear-containers-tests-fedora-26-master/config.xml
+++ b/jobs/clear-containers-tests-fedora-26-master/config.xml
@@ -46,24 +46,7 @@
 
 set -e
 
-export PATH=$PATH:/usr/sbin
-export GOROOT=/usr/local/go
-mkdir -p $HOME/go
-export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH
-
-echo &quot;GOROOT=$GOROOT&quot;
-echo &quot;GOPATH=$GOPATH&quot;
-echo &quot;PATH=$PATH&quot;
-echo &quot;USER=$USER&quot;
-
-export CI=true
-go get github.com/clearcontainers/tests || true
-cd $GOPATH/src/github.com/clearcontainers/tests
-git fetch origin &amp;&amp; git checkout origin/master
-sudo -E PATH=$PATH bash -c &quot;.ci/setup_tests.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;.ci/setup.sh&quot;
-sudo -E PATH=$PATH bash -c &quot;make check&quot;</command>
+.ci/jenkins_job_build.sh &quot;github.com/clearcontainers/tests&quot;</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/org.jenkinsci.plugins.cloudstats.CloudStatistics.xml
+++ b/org.jenkinsci.plugins.cloudstats.CloudStatistics.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<org.jenkinsci.plugins.cloudstats.CloudStatistics plugin="cloud-stats@0.13">
+<org.jenkinsci.plugins.cloudstats.CloudStatistics plugin="cloud-stats@0.14">
   <active class="java.util.concurrent.CopyOnWriteArrayList">
     <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
       <id>
@@ -305,15 +305,15 @@
       <id>
         <cloudName>jenkins-azure-cloud</cloudName>
         <templateName>jenkins-azure-vm-fedora-26</templateName>
-        <fingerprint>-1117508730</fingerprint>
+        <fingerprint>-1994021094</fingerprint>
       </id>
-      <name>jenkins-azure-vm-fedora-26-b7e390</name>
+      <name>jenkins-azure-vm-fedora-26-3a3bb0</name>
       <progress class="linked-hash-map">
         <entry>
           <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
           <org.jenkinsci.plugins.cloudstats.PhaseExecution>
             <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-            <started>1506962665399</started>
+            <started>1507039272250</started>
             <phase>PROVISIONING</phase>
           </org.jenkinsci.plugins.cloudstats.PhaseExecution>
         </entry>
@@ -321,7 +321,7 @@
           <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
           <org.jenkinsci.plugins.cloudstats.PhaseExecution>
             <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-            <started>1506962820202</started>
+            <started>1507039459154</started>
             <phase>LAUNCHING</phase>
           </org.jenkinsci.plugins.cloudstats.PhaseExecution>
         </entry>
@@ -329,7 +329,273 @@
           <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
           <org.jenkinsci.plugins.cloudstats.PhaseExecution>
             <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-            <started>1506962964996</started>
+            <started>1507039608005</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-fedora-26</templateName>
+        <fingerprint>-1681566273</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-fedora-26-8b42d0</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039442249</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039628139</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039791364</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+        <fingerprint>-254127331</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-ubuntu-16-04-template3f20a0</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039742249</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039897783</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040021725</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+        <fingerprint>-1260051425</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-ubuntu-17-04-template40f9f0</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039742250</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039898266</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040055252</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-fedora-26</templateName>
+        <fingerprint>-339338523</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-fedora-26-3a5af0</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507039952249</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040138455</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040389707</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+        <fingerprint>-1263146080</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-ubuntu-16-04-templatea219b0</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040702249</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040857235</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040985993</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+        <fingerprint>-1844842738</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-ubuntu-17-04-templatea3f300</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040702255</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040887950</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507041050739</started>
+            <phase>OPERATING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <null/>
+        </entry>
+      </progress>
+    </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+    <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <id>
+        <cloudName>jenkins-azure-cloud</cloudName>
+        <templateName>jenkins-azure-vm-fedora-26</templateName>
+        <fingerprint>-582600945</fingerprint>
+      </id>
+      <name>jenkins-azure-vm-fedora-26-7451a0</name>
+      <progress class="linked-hash-map">
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040722249</started>
+            <phase>PROVISIONING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507040877350</started>
+            <phase>LAUNCHING</phase>
+          </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+        </entry>
+        <entry>
+          <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+          <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+            <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+            <started>1507041044682</started>
             <phase>OPERATING</phase>
           </org.jenkinsci.plugins.cloudstats.PhaseExecution>
         </entry>
@@ -346,15 +612,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-275490698</fingerprint>
+          <fingerprint>-828304900</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template3c3300</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-template523fd0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725597364</started>
+              <started>1506971348377</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -362,7 +628,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725752567</started>
+              <started>1506971534941</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -370,7 +636,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725952838</started>
+              <started>1506971670697</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -378,7 +644,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506726466124</started>
+              <started>1506973680526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -387,16 +653,16 @@
       <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-919563617</fingerprint>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-270081242</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template3c4110</name>
+        <name>jenkins-azure-vm-ubuntu-17-04-template541920</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725607364</started>
+              <started>1506971348386</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -404,7 +670,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725792786</started>
+              <started>1506971504368</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -412,7 +678,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506726017348</started>
+              <started>1506971731506</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -420,7 +686,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506726466124</started>
+              <started>1506973680526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -430,15 +696,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-297699526</fingerprint>
+          <fingerprint>-736426956</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-d250a0</name>
+        <name>jenkins-azure-vm-fedora-26-b3f910</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727207370</started>
+              <started>1506972658356</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -446,7 +712,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727363072</started>
+              <started>1506972814456</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -454,7 +720,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727507782</started>
+              <started>1506972974927</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -462,7 +728,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506728266123</started>
+              <started>1506975480526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -472,15 +738,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-2019996809</fingerprint>
+          <fingerprint>-1549114644</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template34dcf0</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatee1dd50</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727207376</started>
+              <started>1506972658357</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -488,7 +754,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727392780</started>
+              <started>1506972845279</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -496,7 +762,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727594601</started>
+              <started>1506973066131</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -504,7 +770,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506728266123</started>
+              <started>1506975480526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -514,15 +780,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1004359978</fingerprint>
+          <fingerprint>-1960598721</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template20e300</name>
+        <name>jenkins-azure-vm-ubuntu-17-04-templatee3b6a0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727207379</started>
+              <started>1506972658371</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -530,7 +796,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727362813</started>
+              <started>1506972814748</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -538,7 +804,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727582937</started>
+              <started>1506973054114</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -546,49 +812,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506728266123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-385821636</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template3aca50</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727337365</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727522273</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727728916</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506728266123</started>
+              <started>1506975480526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -598,15 +822,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-2011418692</fingerprint>
+          <fingerprint>-1755433279</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template585f80</name>
+        <name>jenkins-azure-vm-ubuntu-17-04-template358110</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727337371</started>
+              <started>1506974528356</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -614,7 +838,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727491942</started>
+              <started>1506974684558</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -622,7 +846,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506727710622</started>
+              <started>1506974854861</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -630,7 +854,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506728266123</started>
+              <started>1506977280526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -640,15 +864,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-921848337</fingerprint>
+          <fingerprint>-1385364611</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-47c610</name>
+        <name>jenkins-azure-vm-fedora-26-7bed20</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730677365</started>
+              <started>1506974638356</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -656,7 +880,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730832986</started>
+              <started>1506974793064</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -664,7 +888,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730975523</started>
+              <started>1506974947400</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -672,7 +896,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
+              <started>1506977280526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -682,15 +906,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1692877367</fingerprint>
+          <fingerprint>-623542573</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template75aa50</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-template35a300</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730677368</started>
+              <started>1506974638363</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -698,7 +922,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730894317</started>
+              <started>1506974823455</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -706,7 +930,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731078010</started>
+              <started>1506975031944</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -714,49 +938,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-235518293</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template7783a0</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730677375</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730863510</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731020239</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
+              <started>1506977280526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -766,15 +948,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-1442154132</fingerprint>
+          <fingerprint>-695586955</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-778dc0</name>
+        <name>jenkins-azure-vm-fedora-26-44c370</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731097373</started>
+              <started>1506980668355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -782,7 +964,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731282704</started>
+              <started>1506980823266</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -790,7 +972,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731434643</started>
+              <started>1506980992152</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -798,301 +980,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1887545322</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-templateaa5830</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731237374</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731392245</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731602778</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-834348626</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-templateac3180</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731237374</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731422143</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731573637</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1115921440</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-templateac0d00</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731297364</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731452590</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731670425</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733066123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1015300191</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template9e6640</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730817381</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731005490</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731227692</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733666123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1579373310</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-templatea03f90</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506730817401</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731034113</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731224877</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733666123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-561692290</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-templateaa6640</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731247364</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731433456</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731632984</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733666123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1368878507</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-templateac3f90</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731247364</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731433333</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506731595160</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733666123</started>
+              <started>1506981480526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1102,15 +990,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-2145643864</fingerprint>
+          <fingerprint>-1482607237</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-f34c00</name>
+        <name>jenkins-azure-vm-fedora-26-1517f0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732617364</started>
+              <started>1506980268356</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1118,7 +1006,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732772466</started>
+              <started>1506980393995</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1126,7 +1014,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732923715</started>
+              <started>1506980556541</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1134,7 +1022,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506734866123</started>
+              <started>1506982080526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1144,15 +1032,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1713997760</fingerprint>
+          <fingerprint>-1454503340</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template3d2710</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-template42fc30</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732627366</started>
+              <started>1506980268365</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1160,7 +1048,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732842694</started>
+              <started>1506980424083</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1168,7 +1056,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733065926</started>
+              <started>1506980644284</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1176,7 +1064,49 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506734866123</started>
+              <started>1506982080526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-1148263602</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-template44d580</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506980268370</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506980424180</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506980642799</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982080526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1186,15 +1116,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-510061441</fingerprint>
+          <fingerprint>-548271793</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template3d2712</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-template7486d0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732627366</started>
+              <started>1506980758358</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1202,7 +1132,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732812388</started>
+              <started>1506980913305</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1210,7 +1140,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733024441</started>
+              <started>1506981130466</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1218,7 +1148,49 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506734866123</started>
+              <started>1506982080526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-1667404239</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template72a7b0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506980668358</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506980883933</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506981022390</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982680526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1228,15 +1200,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1988717937</fingerprint>
+          <fingerprint>-1410252869</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template3f0061</name>
+        <name>jenkins-azure-vm-ubuntu-17-04-template748100</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732627367</started>
+              <started>1506980668366</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1244,7 +1216,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732873188</started>
+              <started>1506980883823</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1252,7 +1224,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733032154</started>
+              <started>1506981077174</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1260,7 +1232,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506734866123</started>
+              <started>1506982680526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1269,16 +1241,16 @@
       <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-408521576</fingerprint>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-105270234</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template3f1c91</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatea60360</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732647364</started>
+              <started>1506981238355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1286,7 +1258,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732863148</started>
+              <started>1506981423960</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1294,7 +1266,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733014638</started>
+              <started>1506981639511</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1302,7 +1274,49 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506734866123</started>
+              <started>1506982680526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-1934417417</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template5574e0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506981828355</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506981983542</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982104768</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982680526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1312,15 +1326,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-2144068902</fingerprint>
+          <fingerprint>-1117508730</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-f42d80</name>
+        <name>jenkins-azure-vm-fedora-26-b7e390</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732627366</started>
+              <started>1506962665399</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1328,7 +1342,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732843027</started>
+              <started>1506962820202</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1336,7 +1350,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732996215</started>
+              <started>1506962964996</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1344,217 +1358,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506735466123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1317502654</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template3d2711</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732627366</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732873118</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733097366</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506735466123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1095395018</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template3f0060</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732627367</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732873465</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733032763</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506735466123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-57148366</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template3f1c90</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732647364</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732862956</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733034035</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506735466123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-2017380449</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template409ed0</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732757364</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506732942570</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506733142291</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506735466123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-720032819</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template96c9e0</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506736987366</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737172988</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737383198</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506739066123</started>
+              <started>1506983880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1564,15 +1368,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-1572906704</fingerprint>
+          <fingerprint>-228801871</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-db8860</name>
+        <name>jenkins-azure-vm-fedora-26-7631f0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506736987364</started>
+              <started>1506981138355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1580,7 +1384,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737173178</started>
+              <started>1506981293356</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1588,7 +1392,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737331862</started>
+              <started>1506981440550</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1596,49 +1400,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506740266123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-509762138</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-templateb45f10</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506736987369</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737173127</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737335496</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506740266123</started>
+              <started>1506983880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1648,15 +1410,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-159887801</fingerprint>
+          <fingerprint>-734115098</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-templatece4660</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatea44e80</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737117364</started>
+              <started>1506981178356</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1664,7 +1426,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737302532</started>
+              <started>1506981364329</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1672,7 +1434,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737510224</started>
+              <started>1506981494534</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1680,49 +1442,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506740266123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1803818301</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-templateebdb90</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737117370</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737271910</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506737487615</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506740266123</started>
+              <started>1506983880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1732,15 +1452,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-847219793</fingerprint>
+          <fingerprint>-355920839</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template4089d0</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-template36a170</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767337375</started>
+              <started>1506981728355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1748,7 +1468,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767492330</started>
+              <started>1506981883150</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1756,7 +1476,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767612077</started>
+              <started>1506982007064</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1764,49 +1484,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506769666123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-234633128</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template426320</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767337375</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767492249</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767642347</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506769666123</started>
+              <started>1506983880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1816,15 +1494,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-1967280172</fingerprint>
+          <fingerprint>-875281996</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-12a5a0</name>
+        <name>jenkins-azure-vm-fedora-26-d756e0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767337370</started>
+              <started>1506981808355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1832,7 +1510,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767553325</started>
+              <started>1506981933490</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1840,7 +1518,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767706057</started>
+              <started>1506982089606</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1848,7 +1526,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506770866123</started>
+              <started>1506983880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1858,15 +1536,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-831437666</fingerprint>
+          <fingerprint>-1678998231</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template6937b0</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-template3f5c11</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767467369</started>
+              <started>1506982608365</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1874,7 +1552,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767652689</started>
+              <started>1506982793346</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1882,7 +1560,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767853695</started>
+              <started>1506982925461</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1890,7 +1568,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506770866123</started>
+              <started>1506983880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1900,15 +1578,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1325240020</fingerprint>
+          <fingerprint>-1097958353</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template6b1100</name>
+        <name>jenkins-azure-vm-ubuntu-17-04-template3c6f00</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767467373</started>
+              <started>1506981708355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1916,7 +1594,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767652607</started>
+              <started>1506981862969</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1924,7 +1602,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506767798025</started>
+              <started>1506982090684</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1932,7 +1610,91 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506770866123</started>
+              <started>1506984480526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-372735310</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template3f5c10</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982608365</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982793876</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506983010870</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506984480526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-1933812241</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-template42bff0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982638355</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982823901</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506982986228</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506984480526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1942,15 +1704,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-1572878747</fingerprint>
+          <fingerprint>-1848836831</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-5c5820</name>
+        <name>jenkins-azure-vm-fedora-26-1177d0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862577366</started>
+              <started>1506982608355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1958,7 +1720,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862762708</started>
+              <started>1506982762956</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1966,7 +1728,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862916798</started>
+              <started>1506982920010</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -1974,175 +1736,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506863266123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-992100016</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template8a3c60</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862577369</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862763073</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862973884</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506863266123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-157821424</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template8c15b0</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862577375</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862762735</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862917333</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506863266123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1962462355</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-template8db420</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862707366</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862861824</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862982750</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506864466123</started>
-              <phase>COMPLETED</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-        </progress>
-      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
-        <id>
-          <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1503832104</fingerprint>
-        </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template8f8d80</name>
-        <progress class="linked-hash-map">
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862707367</started>
-              <phase>PROVISIONING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506862892282</started>
-              <phase>LAUNCHING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506863113207</started>
-              <phase>OPERATING</phase>
-            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
-          </entry>
-          <entry>
-            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
-            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
-              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506864466123</started>
+              <started>1506985080526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2152,15 +1746,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-fedora-26</templateName>
-          <fingerprint>-1562965336</fingerprint>
+          <fingerprint>-1164275963</fingerprint>
         </id>
-        <name>jenkins-azure-vm-fedora-26-bb35c0</name>
+        <name>jenkins-azure-vm-fedora-26-72bc10</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506927967366</started>
+              <started>1506983508355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2168,7 +1762,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928122110</started>
+              <started>1506983663097</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2176,7 +1770,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928274888</started>
+              <started>1506983810495</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2184,7 +1778,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506931066123</started>
+              <started>1506986280526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2194,15 +1788,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1770434883</fingerprint>
+          <fingerprint>-1329825984</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-templatee91a00</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatea22ae0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506927967368</started>
+              <started>1506983538355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2210,7 +1804,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928122062</started>
+              <started>1506983723931</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2218,7 +1812,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928247134</started>
+              <started>1506983942167</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2226,7 +1820,91 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506931066123</started>
+              <started>1506986280526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-1435967822</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatea22ae1</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506983538355</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506983723888</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506983935935</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506986280526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-2099350182</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template699660</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985268356</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985423939</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985552764</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506986280526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2236,15 +1914,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-186888844</fingerprint>
+          <fingerprint>-1338513738</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-templateeaf350</name>
+        <name>jenkins-azure-vm-ubuntu-17-04-templatea42e70</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506927967376</started>
+              <started>1506983568355</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2252,7 +1930,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928122019</started>
+              <started>1506983723307</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2260,7 +1938,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928330674</started>
+              <started>1506983890573</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2268,7 +1946,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506931066123</started>
+              <started>1506986880526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2278,15 +1956,15 @@
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
           <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
-          <fingerprint>-1993066016</fingerprint>
+          <fingerprint>-223440309</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-16-04-templateec91d0</name>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatede48e0</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928097371</started>
+              <started>1506984838356</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2294,7 +1972,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928282906</started>
+              <started>1506984999427</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2302,7 +1980,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506928488559</started>
+              <started>1506985126534</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -2310,7 +1988,595 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506931066123</started>
+              <started>1506987480526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-1433305916</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-template12e110</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506984908356</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985063328</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985286934</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506988080526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-fedora-26</templateName>
+          <fingerprint>-251829820</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-fedora-26-e32390</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506984908356</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985063734</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506985232880</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506988680526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-136811572</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatea20280</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506986008355</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506986194134</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506986409784</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1506989280526</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-fedora-26</templateName>
+          <fingerprint>-1271267842</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-fedora-26-b65550</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017312262</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017467754</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017679131</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507020220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-1283632153</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-templatee43990</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017312285</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017467846</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017589602</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507020220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-623236972</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-templatee612e0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017312294</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017467873</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507017688792</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507020220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-fedora-26</templateName>
+          <fingerprint>-1105314599</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-fedora-26-46b9c0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035452257</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035577240</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035789878</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507038220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-1838715758</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template749e00</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035452261</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035608324</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035736333</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507038220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-576005913</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-template767750</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035452272</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035638092</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507035800338</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507038220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-813756100</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template66dcf0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037452249</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037638404</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037772417</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507040020845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-1645627210</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-template68b650</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037452257</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037607964</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037827215</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507040020845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-fedora-26</templateName>
+          <fingerprint>-2417720</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-fedora-26-3a7530</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037472249</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037627109</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507037811805</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507041220845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-16-04-template</templateName>
+          <fingerprint>-515608854</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-16-04-template3187f0</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507039272252</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507039458414</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507039599423</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507041820845</started>
+              <phase>COMPLETED</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+        </progress>
+      </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+      <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
+        <id>
+          <cloudName>jenkins-azure-cloud</cloudName>
+          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
+          <fingerprint>-605166976</fingerprint>
+        </id>
+        <name>jenkins-azure-vm-ubuntu-17-04-template336140</name>
+        <progress class="linked-hash-map">
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507039272253</started>
+              <phase>PROVISIONING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507039458361</started>
+              <phase>LAUNCHING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507039628074</started>
+              <phase>OPERATING</phase>
+            </org.jenkinsci.plugins.cloudstats.PhaseExecution>
+          </entry>
+          <entry>
+            <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
+            <org.jenkinsci.plugins.cloudstats.PhaseExecution>
+              <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
+              <started>1507041820845</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -4503,16 +4769,16 @@
       <org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
         <id>
           <cloudName>jenkins-azure-cloud</cloudName>
-          <templateName>jenkins-azure-vm-ubuntu-17-04-template</templateName>
-          <fingerprint>-1957026677</fingerprint>
+          <templateName>jenkins-azure-vm-fedora-26</templateName>
+          <fingerprint>-530820037</fingerprint>
         </id>
-        <name>jenkins-azure-vm-ubuntu-17-04-template3c8fd0</name>
+        <name>jenkins-azure-vm-fedora-26-245b90</name>
         <progress class="linked-hash-map">
           <entry>
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>PROVISIONING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725577364</started>
+              <started>1506971348369</started>
               <phase>PROVISIONING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -4520,7 +4786,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>LAUNCHING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725762388</started>
+              <started>1506971504031</started>
               <phase>LAUNCHING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -4528,7 +4794,7 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>OPERATING</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506725913076</started>
+              <started>1506971652501</started>
               <phase>OPERATING</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
@@ -4536,14 +4802,14 @@
             <org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>COMPLETED</org.jenkinsci.plugins.cloudstats.ProvisioningActivity_-Phase>
             <org.jenkinsci.plugins.cloudstats.PhaseExecution>
               <attachments class="java.util.concurrent.CopyOnWriteArrayList"/>
-              <started>1506726466124</started>
+              <started>1506973680526</started>
               <phase>COMPLETED</phase>
             </org.jenkinsci.plugins.cloudstats.PhaseExecution>
           </entry>
         </progress>
       </org.jenkinsci.plugins.cloudstats.ProvisioningActivity>
     </data>
-    <next>99</next>
+    <next>47</next>
     <size>100</size>
   </log>
 </org.jenkinsci.plugins.cloudstats.CloudStatistics>


### PR DESCRIPTION
A shared script has been introduced in the tests repo and all the
Jenkins jobs have been updated accordingly. This commit make sure
that we store this update.

Fixes #14