### PR TITLE
update jenkins configuration

### DIFF
--- a/credentials.xml
+++ b/credentials.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin="credentials@2.1.14">
+<com.cloudbees.plugins.credentials.SystemCredentialsProvider plugin="credentials@2.1.16">
   <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
     <entry>
       <com.cloudbees.plugins.credentials.domains.Domain>
@@ -76,6 +76,12 @@
           <id>c762d747-641a-4891-8522-26cae9defc3f</id>
           <description>Coveralls agent repository token</description>
           <secret>{AQAAABAAAAAwH44271ZXFv6vwAmfBLHHG8DS1hAhQrd/glafTJtTn5kAhqjROddzqQJFUHC4reI8ROoKQ55EwRlfaSLs45PHsw==}</secret>
+        </org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl>
+        <org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl plugin="plain-credentials@1.4">
+          <scope>GLOBAL</scope>
+          <id>78b78ee1-1848-40f1-8a1f-9ef33b92e4ce</id>
+          <description>Coveralls virtcontainers repository token</description>
+          <secret>{AQAAABAAAAAwRipW8OIQ/NEAY9G+GYwhshHw/+2EOtae6wAzw/y8LUwcDq93XmfXqfosD09yxPHFdBEfghzSBVCMhfPpUL2/OQ==}</secret>
         </org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl>
       </java.util.concurrent.CopyOnWriteArrayList>
     </entry>

--- a/jobs/clear-containers-agent-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-16-04-PR/config.xml
@@ -119,15 +119,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-agent-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-16-04-master/config.xml
@@ -73,15 +73,8 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
 &#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-agent-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-17-04-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-agent-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-agent-azure-ubuntu-17-04-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-agent-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-agent-fedora-26-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-agent-fedora-26-master/config.xml
+++ b/jobs/clear-containers-agent-fedora-26-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-proxy-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-16-04-PR/config.xml
@@ -119,15 +119,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-proxy-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-16-04-master/config.xml
@@ -73,15 +73,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-proxy-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-17-04-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-proxy-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-proxy-azure-ubuntu-17-04-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-proxy-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-proxy-fedora-26-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-proxy-fedora-26-master/config.xml
+++ b/jobs/clear-containers-proxy-fedora-26-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-runtime-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-16-04-PR/config.xml
@@ -119,15 +119,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-runtime-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-16-04-master/config.xml
@@ -73,15 +73,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-runtime-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-17-04-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-runtime-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-runtime-azure-ubuntu-17-04-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-runtime-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-runtime-fedora-26-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-runtime-fedora-26-master/config.xml
+++ b/jobs/clear-containers-runtime-fedora-26-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-shim-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-16-04-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-shim-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-16-04-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-shim-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-17-04-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-shim-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-shim-azure-ubuntu-17-04-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-shim-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-shim-fedora-26-PR/config.xml
@@ -118,15 +118,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-shim-fedora-26-master/config.xml
+++ b/jobs/clear-containers-shim-fedora-26-master/config.xml
@@ -71,15 +71,7 @@ cd tests
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-tests-azure-ubuntu-16-04-PR/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-16-04-PR/config.xml
@@ -114,15 +114,7 @@ export ghprbTargetBranch
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-tests-azure-ubuntu-16-04-master/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-16-04-master/config.xml
@@ -67,15 +67,7 @@ set -e
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-tests-azure-ubuntu-17-04-PR/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-17-04-PR/config.xml
@@ -114,15 +114,7 @@ export ghprbTargetBranch
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-tests-azure-ubuntu-17-04-master/config.xml
+++ b/jobs/clear-containers-tests-azure-ubuntu-17-04-master/config.xml
@@ -67,15 +67,7 @@ set -e
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-tests-fedora-26-PR/config.xml
+++ b/jobs/clear-containers-tests-fedora-26-PR/config.xml
@@ -114,15 +114,7 @@ export ghprbTargetBranch
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/clear-containers-tests-fedora-26-master/config.xml
+++ b/jobs/clear-containers-tests-fedora-26-master/config.xml
@@ -67,15 +67,7 @@ set -e
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>

--- a/jobs/virtcontainers-fedora-26-PR/config.xml
+++ b/jobs/virtcontainers-fedora-26-PR/config.xml
@@ -93,10 +93,6 @@ set -e
 export ghprbPullId
 export ghprbTargetBranch
 
-cd $HOME
-git clone https://github.com/containers/virtcontainers
-cd virtcontainers/
-
 .ci/jenkins_job_build.sh</command>
     </hudson.tasks.Shell>
   </builders>
@@ -110,7 +106,7 @@ cd virtcontainers/
               <operator>OR</operator>
             </hudson.plugins.postbuildtask.LogProperties>
             <hudson.plugins.postbuildtask.LogProperties>
-              <logText>Build step `Execute shell` marked as failure</logText>
+              <logText>Build step &apos;Execute shell&apos; marked as failure</logText>
               <operator>AND</operator>
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
@@ -118,21 +114,21 @@ cd virtcontainers/
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>
         </hudson.plugins.postbuildtask.TaskProperties>
       </tasks>
     </hudson.plugins.postbuildtask.PostbuildTask>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>cc-proxy_*,cc-runtime_*,cc-shim_*,crio_*</artifacts>
+      <allowEmptyArchive>true</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
     <com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction plugin="azure-vm-agents@0.4.7.1">
       <agentPostBuildAction>Delete agent after build execution (when idle).</agentPostBuildAction>
     </com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction>

--- a/jobs/virtcontainers-fedora-26-master/config.xml
+++ b/jobs/virtcontainers-fedora-26-master/config.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <project>
+  <actions/>
   <description></description>
   <keepDependencies>false</keepDependencies>
   <properties>
@@ -45,13 +46,6 @@
 
 set -e
 
-export ghprbPullId
-export ghprbTargetBranch
-
-cd $HOME
-git clone https://github.com/containers/virtcontainers
-cd virtcontainers/
-
 .ci/jenkins_job_build.sh</command>
     </hudson.tasks.Shell>
   </builders>
@@ -65,29 +59,28 @@ cd virtcontainers/
               <operator>OR</operator>
             </hudson.plugins.postbuildtask.LogProperties>
             <hudson.plugins.postbuildtask.LogProperties>
-              <logText>Build step `Execute shell` marked as failure</logText>
+              <logText>Build step &apos;Execute shell&apos; marked as failure</logText>
               <operator>AND</operator>
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
           <EscalateStatus>false</EscalateStatus>
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
-&#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>
         </hudson.plugins.postbuildtask.TaskProperties>
       </tasks>
     </hudson.plugins.postbuildtask.PostbuildTask>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>cc-proxy_*,cc-runtime_*,cc-shim_*,crio_*</artifacts>
+      <allowEmptyArchive>true</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
     <com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction plugin="azure-vm-agents@0.4.7.1">
       <agentPostBuildAction>Delete agent after build execution (when idle).</agentPostBuildAction>
     </com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction>

--- a/jobs/virtcontainers-ubuntu-16-04-PR/config.xml
+++ b/jobs/virtcontainers-ubuntu-16-04-PR/config.xml
@@ -92,10 +92,7 @@ set -e
 
 export ghprbPullId
 export ghprbTargetBranch
-
-cd $HOME
-git clone https://github.com/containers/virtcontainers
-cd virtcontainers/
+export COVERALLS_REPO_TOKEN
 
 .ci/jenkins_job_build.sh</command>
     </hudson.tasks.Shell>
@@ -110,7 +107,7 @@ cd virtcontainers/
               <operator>OR</operator>
             </hudson.plugins.postbuildtask.LogProperties>
             <hudson.plugins.postbuildtask.LogProperties>
-              <logText>Build step `Execute shell` marked as failure</logText>
+              <logText>Build step &apos;Execute shell&apos; marked as failure</logText>
               <operator>AND</operator>
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
@@ -118,21 +115,21 @@ cd virtcontainers/
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>
         </hudson.plugins.postbuildtask.TaskProperties>
       </tasks>
     </hudson.plugins.postbuildtask.PostbuildTask>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>cc-proxy_*,cc-runtime_*,cc-shim_*,crio_*</artifacts>
+      <allowEmptyArchive>true</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
     <com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction plugin="azure-vm-agents@0.4.7.1">
       <agentPostBuildAction>Delete agent after build execution (when idle).</agentPostBuildAction>
     </com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction>
@@ -148,5 +145,13 @@ cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.5.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.13">
+      <bindings>
+        <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+          <credentialsId>78b78ee1-1848-40f1-8a1f-9ef33b92e4ce</credentialsId>
+          <variable>COVERALLS_REPO_TOKEN</variable>
+        </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+      </bindings>
+    </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
   </buildWrappers>
 </project>

--- a/jobs/virtcontainers-ubuntu-16-04-master/config.xml
+++ b/jobs/virtcontainers-ubuntu-16-04-master/config.xml
@@ -46,13 +46,44 @@
 
 set -e
 
-cd $HOME
-git clone https://github.com/containers/virtcontainers
-cd virtcontainers/
+export COVERALLS_REPO_TOKEN
+
 .ci/jenkins_job_build.sh</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
+    <hudson.plugins.postbuildtask.PostbuildTask plugin="postbuild-task@1.8">
+      <tasks>
+        <hudson.plugins.postbuildtask.TaskProperties>
+          <logTexts>
+            <hudson.plugins.postbuildtask.LogProperties>
+              <logText>Build was aborted</logText>
+              <operator>OR</operator>
+            </hudson.plugins.postbuildtask.LogProperties>
+            <hudson.plugins.postbuildtask.LogProperties>
+              <logText>Build step &apos;Execute shell&apos; marked build as failure</logText>
+              <operator>AND</operator>
+            </hudson.plugins.postbuildtask.LogProperties>
+          </logTexts>
+          <EscalateStatus>false</EscalateStatus>
+          <RunIfJobSuccessful>false</RunIfJobSuccessful>
+          <script>#!/bin/bash&#xd;
+&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
+&#xd;
+cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
+.ci/teardown.sh &quot;$WORKSPACE&quot;</script>
+        </hudson.plugins.postbuildtask.TaskProperties>
+      </tasks>
+    </hudson.plugins.postbuildtask.PostbuildTask>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>cc-proxy_*,cc-runtime_*,cc-shim_*,crio_*</artifacts>
+      <allowEmptyArchive>true</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
     <com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction plugin="azure-vm-agents@0.4.7.1">
       <agentPostBuildAction>Delete agent after build execution (when idle).</agentPostBuildAction>
     </com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction>
@@ -68,5 +99,13 @@ cd virtcontainers/
     <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.5.2">
       <colorMapName>xterm</colorMapName>
     </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+    <org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.13">
+      <bindings>
+        <org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+          <credentialsId>78b78ee1-1848-40f1-8a1f-9ef33b92e4ce</credentialsId>
+          <variable>COVERALLS_REPO_TOKEN</variable>
+        </org.jenkinsci.plugins.credentialsbinding.impl.StringBinding>
+      </bindings>
+    </org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>
   </buildWrappers>
 </project>

--- a/jobs/virtcontainers-ubuntu-17-04-PR/config.xml
+++ b/jobs/virtcontainers-ubuntu-17-04-PR/config.xml
@@ -93,10 +93,6 @@ set -e
 export ghprbPullId
 export ghprbTargetBranch
 
-cd $HOME
-git clone https://github.com/containers/virtcontainers
-cd virtcontainers/
-
 .ci/jenkins_job_build.sh</command>
     </hudson.tasks.Shell>
   </builders>
@@ -110,7 +106,7 @@ cd virtcontainers/
               <operator>OR</operator>
             </hudson.plugins.postbuildtask.LogProperties>
             <hudson.plugins.postbuildtask.LogProperties>
-              <logText>Build step `Execute shell` marked as failure</logText>
+              <logText>Build step &apos;Execute shell&apos; marked as failure</logText>
               <operator>AND</operator>
             </hudson.plugins.postbuildtask.LogProperties>
           </logTexts>
@@ -118,21 +114,21 @@ cd virtcontainers/
           <RunIfJobSuccessful>false</RunIfJobSuccessful>
           <script>#!/bin/bash&#xd;
 &#xd;
-export GOROOT=/usr/local/go&#xd;
-export GOPATH=$HOME/go&#xd;
-export PATH=$GOPATH/bin:/usr/local/go/bin:$PATH&#xd;
-&#xd;
-echo &quot;GOROOT=$GOROOT&quot;&#xd;
-echo &quot;GOPATH=$GOPATH&quot;&#xd;
-echo &quot;PATH=$PATH&quot;&#xd;
-echo &quot;USER=$USER&quot;&#xd;
-echo &quot;WORKSPACE=$WORKSPACE&quot;&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
 &#xd;
 cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
 .ci/teardown.sh &quot;$WORKSPACE&quot;</script>
         </hudson.plugins.postbuildtask.TaskProperties>
       </tasks>
     </hudson.plugins.postbuildtask.PostbuildTask>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>cc-proxy_*,cc-runtime_*,cc-shim_*,crio_*</artifacts>
+      <allowEmptyArchive>true</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
     <com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction plugin="azure-vm-agents@0.4.7.1">
       <agentPostBuildAction>Delete agent after build execution (when idle).</agentPostBuildAction>
     </com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction>

--- a/jobs/virtcontainers-ubuntu-17-04-master/config.xml
+++ b/jobs/virtcontainers-ubuntu-17-04-master/config.xml
@@ -46,13 +46,42 @@
 
 set -e
 
-cd $HOME
-git clone https://github.com/containers/virtcontainers
-cd virtcontainers/
 .ci/jenkins_job_build.sh</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>
+    <hudson.plugins.postbuildtask.PostbuildTask plugin="postbuild-task@1.8">
+      <tasks>
+        <hudson.plugins.postbuildtask.TaskProperties>
+          <logTexts>
+            <hudson.plugins.postbuildtask.LogProperties>
+              <logText>Build was aborted</logText>
+              <operator>OR</operator>
+            </hudson.plugins.postbuildtask.LogProperties>
+            <hudson.plugins.postbuildtask.LogProperties>
+              <logText>Build step &apos;Execute shell&apos; marked build as failure</logText>
+              <operator>AND</operator>
+            </hudson.plugins.postbuildtask.LogProperties>
+          </logTexts>
+          <EscalateStatus>false</EscalateStatus>
+          <RunIfJobSuccessful>false</RunIfJobSuccessful>
+          <script>#!/bin/bash&#xd;
+&#xd;
+export GOPATH=$WORKSPACE/go&#xd;
+&#xd;
+cd $GOPATH/src/github.com/clearcontainers/tests&#xd;
+.ci/teardown.sh &quot;$WORKSPACE&quot;</script>
+        </hudson.plugins.postbuildtask.TaskProperties>
+      </tasks>
+    </hudson.plugins.postbuildtask.PostbuildTask>
+    <hudson.tasks.ArtifactArchiver>
+      <artifacts>cc-proxy_*,cc-runtime_*,cc-shim_*,crio_*</artifacts>
+      <allowEmptyArchive>true</allowEmptyArchive>
+      <onlyIfSuccessful>false</onlyIfSuccessful>
+      <fingerprint>false</fingerprint>
+      <defaultExcludes>true</defaultExcludes>
+      <caseSensitive>true</caseSensitive>
+    </hudson.tasks.ArtifactArchiver>
     <com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction plugin="azure-vm-agents@0.4.7.1">
       <agentPostBuildAction>Delete agent after build execution (when idle).</agentPostBuildAction>
     </com.microsoft.azure.vmagent.AzureVMAgentPostBuildAction>

--- a/users/gabyct/config.xml
+++ b/users/gabyct/config.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <user>
-  <fullName>GabyCT</fullName>
+  <fullName>gabyct</fullName>
   <properties>
     <jenkins.security.ApiTokenProperty>
       <apiToken>{AQAAABAAAAAw5E3g534SBGl6F2ZqE1jP/auGsfl8hSIUJ3d6tBejDv1nwP+TA851VgttEEogQDmLdOy4E8aZukj7hf5+J4HG+w==}</apiToken>
@@ -22,11 +22,13 @@
         </hudson.model.AllView>
       </views>
     </hudson.model.MyViewsProperty>
-    <org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty plugin="display-url-api@2.0">
+    <org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty plugin="display-url-api@2.1.0">
       <providerId>default</providerId>
     </org.jenkinsci.plugins.displayurlapi.user.PreferredProviderUserProperty>
     <hudson.model.PaneStatusProperties>
-      <collapsed/>
+      <collapsed>
+        <string>buildQueue</string>
+      </collapsed>
     </hudson.model.PaneStatusProperties>
     <hudson.search.UserSearchProperty>
       <insensitiveSearch>true</insensitiveSearch>


### PR DESCRIPTION
This PR contains 3 commits: 
1. Update `users` directory.
2. Add coveralls token to run coveralls on virtcontainers repo.
3. Update jobs' post-build-task:
  This change updates the location of the GOPATH path from
$HOME/go to $WORKSPACE/go in the post-build-task, so the
teardown.sh script is found by jenkins.
  Also the virtcontainers jobs are now configured to save
the artifacts (logs) after a failure occur.